### PR TITLE
Enclosed the wp_enqueue_style function inside of wp_enqueue_scripts hook

### DIFF
--- a/lib/admin.functions.php
+++ b/lib/admin.functions.php
@@ -7,8 +7,10 @@ require_once(get_template_directory().'/lib/tgm-plugin-activation/plugins.php');
 /*
 Enqueue an admin-specific css file.
 */
-wp_enqueue_style( 'btadmin', get_template_directory_uri().'/lib/css/admin.css', array(), cache_bust() );
-
+function admin_scripts(){
+	wp_enqueue_style( 'btadmin', get_template_directory_uri().'/lib/css/admin.css', array(), cache_bust() );
+}
+add_action( 'wp_enqueue_scripts', 'admin_scripts' );
 /*
 Call various functions that display notices in the admin.
 */


### PR DESCRIPTION
After switching wp_debug to true in wp-config.php this error occurs:
Notice: wp_enqueue_style was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. Please see Debugging in WordPress for more information. (This message was added in version 3.3.) in /var/www/html/public/tigertest/wp-includes/functions.php on line 3792

This fixes the error.